### PR TITLE
feat: persist collapsible states to `window.localStorage` (if available)

### DIFF
--- a/src/lib/components/quests/0003-daily-tweet.svelte
+++ b/src/lib/components/quests/0003-daily-tweet.svelte
@@ -76,7 +76,6 @@
   );
 
   $: {
-    console.log($collapsed);
     if (typeof document !== 'undefined')
       document.body.style.overflow =
         $collapsed ? ''

--- a/src/lib/components/quests/0003-daily-tweet.svelte
+++ b/src/lib/components/quests/0003-daily-tweet.svelte
@@ -10,8 +10,8 @@
   import Quest from '$lib/components/Quest.svelte';
   import type { QuestCallError } from '$lib/quests';
   import type { Profile, TweetSelect } from '$lib/server/db';
+  import { persisted } from '$lib/store';
   import { getUTCDayStart } from '$lib/utils/date';
-  import { suffix } from '$lib/utils/number';
   import { cn } from '$lib/utils/ui';
 
   import { Button } from '../ui/button';
@@ -48,7 +48,10 @@
     return tweetsByDate;
   }, new Map<number, Tweet[]>());
 
-  $: collapsedDates = Array.from(tweetsByDate.keys());
+  $: collapsedDates = persisted(
+    `${id}:collapsed:tweets`,
+    Array.from(tweetsByDate.keys())
+  );
 
   // Form things
   let formData: { id: string } | { errors: QuestCallError[] } | undefined =
@@ -67,13 +70,16 @@
 
   // Collapse code
   const MIN_MEDIA = '(min-width: 768px) and (min-height: 768px)';
-  let collapsed =
-    typeof window !== 'undefined' && !window.matchMedia(MIN_MEDIA).matches;
+  let collapsed = persisted(
+    `${id}:collapsed`,
+    typeof window === 'undefined' ? true : !window.matchMedia(MIN_MEDIA).matches
+  );
 
   $: {
+    console.log($collapsed);
     if (typeof document !== 'undefined')
       document.body.style.overflow =
-        collapsed ? ''
+        $collapsed ? ''
         : !window.matchMedia(MIN_MEDIA).matches ? 'hidden'
         : '';
   }
@@ -87,7 +93,7 @@
   {...$$restProps}
   class={cn(
     'fixed bottom-0 right-0 z-[1] w-full max-w-[575px] bg-brand-black/90 shadow-none backdrop-blur transition-all before:hidden after:hidden hover:transform-none max-md:h-[100dvh]',
-    collapsed ?
+    $collapsed ?
       'max-h-[3rem] overflow-hidden'
     : 'max-h-[100dvh] md:max-h-[75dvh]'
   )}
@@ -99,11 +105,11 @@
     <button
       class="ml-auto mr-4 flex size-8 items-center justify-center rounded border border-muted"
       on:click={() => {
-        collapsed = !collapsed;
+        collapsed.update((value) => !value);
       }}
       type="button"
     >
-      {#if !collapsed}
+      {#if !$collapsed}
         <ChevronsDownUp size={16} />
       {:else}
         <ChevronsUpDown size={16} />
@@ -138,23 +144,26 @@
               <button
                 class="ml-auto mr-4 flex size-8 items-center justify-center rounded border border-muted"
                 on:click={() => {
-                  collapsedDates =
-                    collapsedDates.includes(date) ?
-                      collapsedDates.filter((_) => _ !== date)
-                    : [...collapsedDates, date];
-                  // @ts-expect-error TODO: types
-                  window?.twttr?.widgets?.load?.();
+                  collapsedDates.update((dates) => {
+                    const nextDates =
+                      dates.includes(date) ?
+                        dates.filter((_) => _ !== date)
+                      : [...dates, date];
+                    // @ts-expect-error TODO: types
+                    window?.twttr?.widgets?.load?.();
+                    return nextDates;
+                  });
                 }}
                 type="button"
               >
-                {#if !collapsedDates.includes(date)}
+                {#if !$collapsedDates.includes(date)}
                   <ChevronsDownUp size={16} />
                 {:else}
                   <ChevronsUpDown size={16} />
                 {/if}
               </button>
             </h3>
-            {#if !collapsedDates.includes(date)}
+            {#if !$collapsedDates.includes(date)}
               <div transition:slide>
                 {#each tweets as status (status.id)}
                   <div

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -28,22 +28,15 @@ export function persisted<T>(
   const key = `${prefix}${name}`;
 
   if (!enabled) {
-    console.warn(`writableStore "${key}" disabled. config:\n`, options);
+    console.warn(`persistable "${key}" disabled.`);
     return writable(initialValue);
   }
-
-  console.log(
-    `writableStore "${key}" initialized with\n`,
-    initialValue,
-    options
-  );
 
   function persist(value?: T) {
     try {
       storage.setItem(key, serialize(value));
     } catch (error) {
-      console.debug(`SET ${key}`, value);
-      console.error(error);
+      console.error(`PersistError: ${key}`, error);
     }
   }
 
@@ -51,8 +44,7 @@ export function persisted<T>(
     try {
       return deserialize(storage.getItem(key) ?? 'null');
     } catch (error) {
-      console.debug(`GET ${key}`, storage.getItem(key));
-      console.error(error);
+      console.error(`RetrieveError: ${key}`, error);
     }
   }
 
@@ -63,7 +55,7 @@ export function persisted<T>(
       persist(value);
       set(value);
     },
-    // run: Subscriber<T>, invalidate?: Invalidator<T> | undefined) => Unsubscriber
+
     subscribe(
       run: Subscriber<T>,
       invalidate?: Invalidator<T> | undefined

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -6,29 +6,41 @@ import {
   writable
 } from 'svelte/store';
 
+/**
+ * Creates a `writable` svelte store which synchronizes with a `Storage`.
+ * By default this is `window.localStorage`. If `options.storage` is
+ * unavailable fall back to a regular in-memory `writable`.
+ */
 export function persisted<T>(
+  /** The name of the store. Storage key will become `[prefix]:[name]`. */
   name: string,
+  /** Initial store value. */
   initialValue?: T,
+  /** Storage configuration options. */
   options?: {
-    enabled?: boolean;
+    /** Prefix used for Storage keys. */
     prefix?: string;
+    /** An object adhering to the `Storage` interface. */
     storage?: Storage;
+    /** Takes a `value` T and serializes to `string`. */
     serialize?: (value: T) => string;
-    deserialize?: (value: string) => T;
+    /** Takes a `string` and serializes to T. */
+    deserialize?: (str: string) => T;
   }
 ) {
   const {
-    enabled = Boolean('localStorage' in globalThis),
     prefix = 'store:',
-    storage = globalThis.localStorage,
+    storage = globalThis?.localStorage,
     serialize = JSON.stringify,
     deserialize = JSON.parse
   } = options ?? {};
 
   const key = `${prefix}${name}`;
 
-  if (!enabled) {
-    console.warn(`persistable "${key}" disabled.`);
+  if (!storage) {
+    console.warn(
+      `persistable "${key}" disabled. Storage "${storage}" not found.`
+    );
     return writable(initialValue);
   }
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,84 @@
+import {
+  type Invalidator,
+  type Subscriber,
+  type Unsubscriber,
+  type Updater,
+  writable
+} from 'svelte/store';
+
+export function persisted<T>(
+  name: string,
+  initialValue?: T,
+  options?: {
+    enabled?: boolean;
+    prefix?: string;
+    storage?: Storage;
+    serialize?: (value: T) => string;
+    deserialize?: (value: string) => T;
+  }
+) {
+  const {
+    enabled = Boolean('localStorage' in globalThis),
+    prefix = 'store:',
+    storage = globalThis.localStorage,
+    serialize = JSON.stringify,
+    deserialize = JSON.parse
+  } = options ?? {};
+
+  const key = `${prefix}${name}`;
+
+  if (!enabled) {
+    console.warn(`writableStore "${key}" disabled. config:\n`, options);
+    return writable(initialValue);
+  }
+
+  console.log(
+    `writableStore "${key}" initialized with\n`,
+    initialValue,
+    options
+  );
+
+  function persist(value?: T) {
+    try {
+      storage.setItem(key, serialize(value));
+    } catch (error) {
+      console.debug(`SET ${key}`, value);
+      console.error(error);
+    }
+  }
+
+  function retrieve() {
+    try {
+      return deserialize(storage.getItem(key) ?? 'null');
+    } catch (error) {
+      console.debug(`GET ${key}`, storage.getItem(key));
+      console.error(error);
+    }
+  }
+
+  const { set, subscribe, update } = writable(retrieve() ?? initialValue);
+
+  return {
+    set(value: T) {
+      persist(value);
+      set(value);
+    },
+    // run: Subscriber<T>, invalidate?: Invalidator<T> | undefined) => Unsubscriber
+    subscribe(
+      run: Subscriber<T>,
+      invalidate?: Invalidator<T> | undefined
+    ): Unsubscriber {
+      return subscribe((value) => {
+        run(retrieve() ?? value);
+      }, invalidate);
+    },
+
+    update(updater: Updater<T>) {
+      update((value) => {
+        const nextValue = updater(value);
+        persist(nextValue);
+        return nextValue;
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Test

- Boot up dev
- Play with Quest 3 collapsibles and refresh page often
- Observe state is persisted; `window.localStorage` has entries related to collapsible state prefixed with `store:`