### PR TITLE
fix: horizontal overflow on smaller screens

### DIFF
--- a/src/lib/components/ui/spinning-wheel/spinning-wheel.svelte
+++ b/src/lib/components/ui/spinning-wheel/spinning-wheel.svelte
@@ -9,7 +9,7 @@
 
 <div class="relative m-auto size-64 p-8">
   <div
-    class="absolute inset-0 rounded-full border-2 border-[--color] transition-transform will-change-transform"
+    class="absolute inset-0 overflow-hidden rounded-full border-2 border-[--color] transition-transform will-change-transform"
     style="transform: rotate({spin}deg)"
   >
     {#each spinningDivision as _, index}

--- a/src/routes/quests/+page.svelte
+++ b/src/routes/quests/+page.svelte
@@ -18,7 +18,7 @@
   <Points points={profilePoints} />
 </div>
 
-<div class="flex flex-wrap justify-center gap-16">
+<div class="my-20 flex flex-wrap justify-center gap-16">
   {#if quests}
     {#each quests as quest (quest.id)}
       <svelte:component


### PR DESCRIPTION
It was caused by our rotated spinner elements escaping the spinner's bounding box.

Edit: also added small amount of margin on our quests list.