### PR TITLE
chore: restore Solana modules and remove usage/imports

### DIFF
--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -1,9 +1,9 @@
 import { type Readable, readable } from 'svelte/store';
 
-// import { browser } from '$app/environment';
-// import { connection } from '$vendor/solana';
+import { browser } from '$app/environment';
+import { connection } from '$vendor/solana';
 
-// const TICK_TIMEOUT = 5_000;
+const TICK_TIMEOUT = 5_000;
 
 export interface SolanaStore {
   block?: number;
@@ -12,15 +12,14 @@ export interface SolanaStore {
 export type SolanaContext = Readable<SolanaStore>;
 
 export function createStore(init: SolanaStore = {}) {
-  // return readable(init, (_, update) => {
-  return readable(init, () => {
+  return readable(init, (_, update) => {
     tick();
 
     async function tick() {
-      // const block = await connection.getBlockHeight();
-      // update((store) => ({ ...store, block }));
-      // // Only update block height on client.
-      // if (browser) setTimeout(tick, TICK_TIMEOUT);
+      const block = await connection.getBlockHeight();
+      update((store) => ({ ...store, block }));
+      // Only update block height on client.
+      if (browser) setTimeout(tick, TICK_TIMEOUT);
     }
   });
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,21 +3,17 @@
 
   // do not remove this import. we use it for vercel analytics
   import { inject } from '@vercel/analytics';
-  import { onMount, setContext } from 'svelte';
+  import { onMount } from 'svelte';
 
+  import { dev } from '$app/environment';
   import { afterNavigate, invalidate } from '$app/navigation';
   import EmojiBackdrop from '$lib/components/EmojiBackdrop.svelte';
   import Navigation from '$lib/components/Navigation.svelte';
-  import { createStore as createSolanaStore } from '$lib/solana';
-  import { createStore as createUserStore } from '$lib/user';
 
   export let data;
   $: ({ session, supabase } = data);
 
-  // setContext('solana', createSolanaStore(data.solana));
-  setContext('user', createUserStore(data.user));
-
-  inject();
+  inject({ mode: dev ? 'development' : 'production' });
 
   onMount(() => {
     const { data } = supabase.auth.onAuthStateChange((_, nextSession) => {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -9,16 +9,10 @@ import {
   PUBLIC_SUPABASE_ANON_KEY,
   PUBLIC_SUPABASE_URL
 } from '$env/static/public';
-// import type { SolanaStore } from '$lib/solana';
 import { parseLocale } from '$lib/utils/locale';
-// import { connection } from '$vendor/solana';
 
 export async function load({ data, depends, fetch }) {
   depends('supabase:auth');
-
-  // const solana: SolanaStore = {
-  //   block: await connection.getBlockHeight()
-  // };
 
   const supabase =
     isBrowser() ?
@@ -44,7 +38,6 @@ export async function load({ data, depends, fetch }) {
   return {
     ...data,
     locale: locale || data.locale,
-    // solana,
     supabase
   };
 }

--- a/src/vendor/solana.ts
+++ b/src/vendor/solana.ts
@@ -1,3 +1,3 @@
-// import { clusterApiUrl, Connection } from '@solana/web3.js';
+import { clusterApiUrl, Connection } from '@solana/web3.js';
 
-// export const connection = new Connection(clusterApiUrl('devnet'));
+export const connection = new Connection(clusterApiUrl('devnet'));


### PR DESCRIPTION
We don't want to trigger the `503`s from Solana's devnet but we don't want to keep the code around to iterate on later. This PR makes sure any module consuming Solana things currently isn't imported. Commented out code has been restored.

Additionally we now pass the proper analytics mode depending on runtime environment. See `src/routes/layout.svelte`